### PR TITLE
Change path manipulation to use Path.Combine instead of string concat

### DIFF
--- a/Source/Steam Library Manager/Forms/Main.cs
+++ b/Source/Steam Library Manager/Forms/Main.cs
@@ -59,7 +59,7 @@ namespace Steam_Library_Manager
             try
             {
                 // Update our setting in memory
-                Properties.Settings.Default.SteamInstallationPath = Path.GetDirectoryName(fileDialog_SelectSteamPath.FileName) + @"\";
+                Properties.Settings.Default.SteamInstallationPath = Path.GetDirectoryName(fileDialog_SelectSteamPath.FileName);
 
                 // Update main form as visual
                 Functions.Settings.UpdateMainForm();

--- a/Source/Steam Library Manager/Forms/MoveGame.cs
+++ b/Source/Steam Library Manager/Forms/MoveGame.cs
@@ -80,16 +80,16 @@ namespace Steam_Library_Manager.Forms
         async void CopyGame(bool Validate, bool RemoveOld, bool Compress, bool deCompress, bool isCompressed)
         {
             // Path definitions
-            string downloadPath = Game.Library.Directory + @"downloading\";
-            string TargetGamePath = Library.Directory + @"common\" + Game.installationPath;
-            string TargetDownloadPath = Library.Directory + @"downloading\" + Game.appID;
+            string downloadPath = Path.Combine(Game.Library.Directory , "downloading");
+            string TargetGamePath = Path.Combine(Library.Directory , "common" , Game.installationPath);
+            string TargetDownloadPath = Path.Combine(Library.Directory , "downloading" , Game.appID.ToString());
             string zipPath = Library.Directory;
 
             // Name definitions
             string acfName = "appmanifest_" + Game.appID + ".acf";
             string workShopACFname = "appworkshop_" + Game.appID + ".acf";
             string zipName = Game.appID + ".zip";
-            string currentZipName = Game.Library.Directory + Game.appID + ".zip";
+            string currentZipName = Path.Combine(Game.Library.Directory , Game.appID.ToString() , ".zip");
             string newFileName;
 
             // Other definitions
@@ -236,7 +236,7 @@ namespace Steam_Library_Manager.Forms
                             }
 
                             // Add .ACF file to archive
-                            await Task.Run(() => gameBackup.CreateEntryFromFile(Game.Library.Directory + acfName, acfName, CompressionLevel.Optimal));
+                            await Task.Run(() => gameBackup.CreateEntryFromFile(Path.Combine(Game.Library.Directory , acfName), acfName, CompressionLevel.Optimal));
 
                             // Log .ACF file
                             Log(".ACF file has been compressed");
@@ -245,7 +245,7 @@ namespace Steam_Library_Manager.Forms
                             if (Directory.Exists(Game.workShopPath))
                             {
                                 // Add Workshop .ACF file to archive
-                                await Task.Run(() => gameBackup.CreateEntryFromFile(Game.Library.Directory + @"workshop\" + workShopACFname, @"workshop\" + workShopACFname, CompressionLevel.Optimal));
+                                await Task.Run(() => gameBackup.CreateEntryFromFile(Path.Combine(Game.Library.Directory , "workshop" , workShopACFname), Path.Combine("workshop" , workShopACFname), CompressionLevel.Optimal));
 
                                 // Log workshop .ACF file
                                 Log("Workshop .ACF file has been compressed");
@@ -376,15 +376,15 @@ namespace Steam_Library_Manager.Forms
 
                         // If game has .patch files in downloading folder
                         // If downloading folder not exists
-                        if (!Directory.Exists(Library.Directory + @"downloading\"))
+                        if (!Directory.Exists(Path.Combine(Library.Directory , "downloading")))
                             // Create downloading folder
-                            Directory.CreateDirectory(Library.Directory + @"downloading\");
+                            Directory.CreateDirectory(Path.Combine(Library.Directory ,"downloading"));
 
                         // For each .patch file in downloading folder
                         foreach (Framework.FileData currentFile in Framework.FastDirectoryEnumerator.EnumerateFiles(downloadPath, "*" + Game.appID + "*.patch", SearchOption.TopDirectoryOnly))
                         {
                             // Set new file name
-                            newFileName = Library.Directory + @"downloading\" + currentFile.Name.Replace(downloadPath, "");
+                            newFileName = Path.Combine(Library.Directory , "downloading" , currentFile.Name.Replace(downloadPath, ""));
 
                             // Copy .patch file to target library asynchronously
                             await Task.Run(() => File.Copy(currentFile.Path, newFileName, true));
@@ -397,7 +397,7 @@ namespace Steam_Library_Manager.Forms
                             foreach (Framework.FileData currentFile in Framework.FastDirectoryEnumerator.EnumerateFiles(Game.workShopPath, "*", SearchOption.AllDirectories))
                             {
                                 // Set new file name
-                                newFileName = Library.Directory + currentFile.Path.Replace(Game.Library.Directory, "");
+                                newFileName = Path.Combine(Library.Directory , currentFile.Path.Replace(Game.Library.Directory, ""));
 
                                 // If directory not exists
                                 if (!Directory.Exists(Path.GetDirectoryName(newFileName)))
@@ -419,13 +419,13 @@ namespace Steam_Library_Manager.Forms
                         }
 
                         // Copy .ACF file
-                        File.Copy(Game.Library.Directory + acfName, Library.Directory + acfName, true);
+                        File.Copy(Path.Combine(Game.Library.Directory , acfName), Path.Combine(Library.Directory , acfName), true);
 
                         // If workshop directory exists
                         if (Directory.Exists(Game.workShopPath))
                         {
                             // Copy workshop .ACF file
-                            File.Copy(Game.Library.Directory + @"workshop\" + workShopACFname, Library.Directory + @"workshop\" + workShopACFname, true);
+                            File.Copy(Path.Combine(Game.Library.Directory , "workshop" , workShopACFname), Path.Combine(Library.Directory , "workshop" , workShopACFname), true);
 
                             // Log to user
                             Log(".ACF file has been created at the target directory");
@@ -483,13 +483,13 @@ namespace Steam_Library_Manager.Forms
                         Log("Old .ACF file has been removed");
 
                     // If workshop .ACf file exists
-                    if (File.Exists(Game.Library.Directory + @"workshop\" + workShopACFname))
+                    if (File.Exists(Path.Combine(Game.Library.Directory , "workshop" , workShopACFname)))
                     {
                         // Remove the file
-                        File.Delete(Game.Library.Directory + @"workshop\" + workShopACFname);
+                        File.Delete(Path.Combine(Game.Library.Directory, "workshop", workShopACFname));
 
                         // If we removed file succesfully
-                        if (!File.Exists(Game.Library.Directory + @"workshop\" + workShopACFname))
+                        if (!File.Exists(Path.Combine(Game.Library.Directory, "workshop", workShopACFname)))
                             // Log to user
                             Log("Workshop .ACF file has been removed");
                     }

--- a/Source/Steam Library Manager/Functions/Games.cs
+++ b/Source/Steam Library Manager/Functions/Games.cs
@@ -67,16 +67,16 @@ namespace Steam_Library_Manager.Functions
                     Game.Library = Library;
 
                     // If game has a folder in "common" dir, define it as exactInstallPath
-                    if (Directory.Exists(Library.Directory + @"common\" + Game.installationPath))
-                        Game.exactInstallPath = Library.Directory + @"common\" + Game.installationPath;
+                    if (Directory.Exists(Path.Combine(Library.Directory ,"common" , Game.installationPath)))
+                        Game.exactInstallPath = Path.Combine(Library.Directory , "common" , Game.installationPath);
 
                     // If game has a folder in "downloading" dir, define it as downloadPath
-                    if (Directory.Exists(Library.Directory + @"downloading\" + Game.appID))
-                        Game.downloadPath = Library.Directory + @"downloading\" + Game.appID;
+                    if (Directory.Exists(Path.Combine(Library.Directory , "downloading" , Game.appID.ToString())))
+                        Game.downloadPath = Path.Combine(Library.Directory, "downloading", Game.appID.ToString());
 
                     // If game has a folder in "workshop" dir, define it as workShopPath
-                    if (Directory.Exists(Library.Directory + @"workshop\content\" + Game.appID))
-                        Game.workShopPath = Library.Directory + @"workshop\content\" + Game.appID;
+                    if (Directory.Exists(Path.Combine(Library.Directory , "workshop", "content" , Game.appID.ToString())))
+                        Game.workShopPath = Path.Combine(Library.Directory, "workshop", "content", Game.appID.ToString());
 
                     // If game do not have a folder in "common" directory and "downloading" directory then skip this game
                     if (Game.exactInstallPath == null && Game.downloadPath == null)

--- a/Source/Steam Library Manager/Functions/SteamLibrary.cs
+++ b/Source/Steam Library Manager/Functions/SteamLibrary.cs
@@ -15,7 +15,7 @@ namespace Steam_Library_Manager.Functions
                     Definitions.List.Library.Clear();
 
                 // If Steam.exe not exists in the path we set then return
-                if (!File.Exists(Properties.Settings.Default.SteamInstallationPath + "Steam.exe")) return;
+                if (!File.Exists(Path.Combine(Properties.Settings.Default.SteamInstallationPath , "Steam.exe"))) return;
 
                 // Our main library doesn't included in LibraryFolders.vdf so we have to include it manually
                 Definitions.List.LibraryList Library = new Definitions.List.LibraryList();
@@ -24,7 +24,7 @@ namespace Steam_Library_Manager.Functions
                 Library.Main = true;
 
                 // Define our library path to SteamApps
-                Library.Directory = Properties.Settings.Default.SteamInstallationPath + @"SteamApps\";
+                Library.Directory = Path.Combine(Properties.Settings.Default.SteamInstallationPath , "SteamApps");
 
                 // Count how many games we have installed in our library
                 Library.GameCount = Games.GetGamesCountFromLibrary(Library);
@@ -36,7 +36,7 @@ namespace Steam_Library_Manager.Functions
                 Framework.KeyValue Key = new Framework.KeyValue();
 
                 // Define our LibraryFolders.VDF path for easier use
-                string vdfFilePath = Properties.Settings.Default.SteamInstallationPath + @"SteamApps\libraryfolders.vdf";
+                string vdfFilePath = Path.Combine(Properties.Settings.Default.SteamInstallationPath , "SteamApps" ,"libraryfolders.vdf");
 
                 // If LibraryFolders.vdf exists
                 if (System.IO.File.Exists(vdfFilePath))
@@ -55,7 +55,7 @@ namespace Steam_Library_Manager.Functions
                         Library = new Definitions.List.LibraryList();
 
                         // Define library path
-                        Library.Directory = Key[i.ToString()].Value + @"\SteamApps\";
+                        Library.Directory = Path.Combine(Key[i.ToString()].Value , "SteamApps");
 
                         // Define game count in library
                         Library.GameCount = Games.GetGamesCountFromLibrary(Library);
@@ -191,16 +191,16 @@ namespace Steam_Library_Manager.Functions
                 if (!Backup)
                 {
                     // Copy Steam.dll as steam needs it
-                    File.Copy(Properties.Settings.Default.SteamInstallationPath + "Steam.dll", newLibraryPath + @"\Steam.dll", true);
+                    File.Copy(Path.Combine(Properties.Settings.Default.SteamInstallationPath , "Steam.dll"), Path.Combine(newLibraryPath , "Steam.dll"), true);
 
                     // create SteamApps directory at requested directory
-                    Directory.CreateDirectory(newLibraryPath + @"\SteamApps");
+                    Directory.CreateDirectory(Path.Combine(newLibraryPath , "SteamApps"));
 
                     // If Steam.dll moved succesfully
-                    if (File.Exists(newLibraryPath + @"\Steam.dll")) // in case of permissions denied
+                    if (File.Exists(Path.Combine(newLibraryPath , "Steam.dll"))) // in case of permissions denied
                     {
                         // Set libraryFolders.vdf path
-                        string vdfPath = Properties.Settings.Default.SteamInstallationPath + @"SteamApps\libraryfolders.vdf";
+                        string vdfPath = Path.Combine(Properties.Settings.Default.SteamInstallationPath , "SteamApps", "libraryfolders.vdf");
 
                         // Call KeyValue in act
                         Framework.KeyValue Key = new Framework.KeyValue();
@@ -232,7 +232,7 @@ namespace Steam_Library_Manager.Functions
                         Properties.Settings.Default.BackupDirectories = new System.Collections.Specialized.StringCollection();
 
                     // Add our newest backup library to settings
-                    Properties.Settings.Default.BackupDirectories.Add(newLibraryPath + @"\");
+                    Properties.Settings.Default.BackupDirectories.Add(newLibraryPath);
 
                     // Update game libraries
                     UpdateLibraries();


### PR DESCRIPTION
Modified all the file and path manipulation to use Path.Combine instead. It make managing path easier since you don't have to manage the \ or use literal string operator(@).